### PR TITLE
Enhance retry decorator to allow catching exception instances

### DIFF
--- a/decorators.py
+++ b/decorators.py
@@ -1,16 +1,17 @@
 import time
 from functools import wraps
 
-
-def retry(ExceptionToCheck, tries=4, delay=3, backoff=2, logger=None):
+def retry(exceptions, tries=4, delay=3, backoff=2, silent=False, logger=None):
     """Retry calling the decorated function using an exponential backoff.
 
     http://www.saltycrane.com/blog/2009/11/trying-out-retry-decorator-python/
     original from: http://wiki.python.org/moin/PythonDecoratorLibrary#Retry
 
-    :param ExceptionToCheck: the exception to check. may be a tuple of
-        exceptions to check
-    :type ExceptionToCheck: Exception or tuple
+    :param exceptions: the exception(s) to check. may be a tuple of
+        exceptions to check.
+    :type exceptions: Exception type, exception instance, or tuple containing
+        any number of both (eg. IOError, IOError(errno.ECOMM), (IOError,), or
+        (ValueError, IOError(errno.ECOMM))
     :param tries: number of times to try (not retry) before giving up
     :type tries: int
     :param delay: initial delay between retries in seconds
@@ -18,9 +19,19 @@ def retry(ExceptionToCheck, tries=4, delay=3, backoff=2, logger=None):
     :param backoff: backoff multiplier e.g. value of 2 will double the delay
         each retry
     :type backoff: int
+    :param silent: If set then no logging will be attempted
+    :type silent: bool
     :param logger: logger to use. If None, print
     :type logger: logging.Logger instance
     """
+    try:
+        len(exceptions)
+    except TypeError:
+        exceptions = (exceptions,)
+    all_exception_types = tuple(set(x if type(x) == type else x.__class__ for x in exceptions))
+    exception_types = tuple(x for x in exceptions if type(x) == type)
+    exception_instances = tuple(x for x in exceptions if type(x) != type)
+
     def deco_retry(f):
 
         @wraps(f)
@@ -29,12 +40,16 @@ def retry(ExceptionToCheck, tries=4, delay=3, backoff=2, logger=None):
             while mtries > 1:
                 try:
                     return f(*args, **kwargs)
-                except ExceptionToCheck, e:
-                    msg = "%s, Retrying in %d seconds..." % (str(e), mdelay)
-                    if logger:
-                        logger.warning(msg)
-                    else:
-                        print msg
+                except all_exception_types as e:
+                    if (not any(x for x in exception_types if isinstance(e, x))
+                        and not any(x for x in exception_instances if type(x) == type(e) and x.args == e.args)):
+                        raise
+                    msg = "%s, Retrying in %d seconds..." % (str(e) if str(e) != "" else repr(e), mdelay)
+                    if not silent:
+                        if logger:
+                            logger.warning(msg)
+                        else:
+                            print msg
                     time.sleep(mdelay)
                     mtries -= 1
                     mdelay *= backoff

--- a/test_decorators.py
+++ b/test_decorators.py
@@ -1,5 +1,6 @@
 import logging
 import unittest
+import errno
 
 from decorators import retry
 
@@ -18,10 +19,10 @@ class UnexpectedError(Exception):
 
 class RetryTestCase(unittest.TestCase):
 
-    def test_no_retry_required(self):
+    def _no_retry_required(self, exception):
         self.counter = 0
 
-        @retry(RetryableError, tries=4, delay=0.1)
+        @retry(exception, tries=4, delay=0.1)
         def succeeds():
             self.counter += 1
             return 'success'
@@ -30,11 +31,15 @@ class RetryTestCase(unittest.TestCase):
 
         self.assertEqual(r, 'success')
         self.assertEqual(self.counter, 1)
+    def test_no_retry_required_type(self):
+        self._no_retry_required(RetryableError)
+    def test_no_retry_required_instance(self):
+        self._no_retry_required(RetryableError())
 
-    def test_retries_once(self):
+    def _retries_once(self, exception):
         self.counter = 0
 
-        @retry(RetryableError, tries=4, delay=0.1)
+        @retry(exception, tries=4, delay=0.1)
         def fails_once():
             self.counter += 1
             if self.counter < 2:
@@ -45,11 +50,15 @@ class RetryTestCase(unittest.TestCase):
         r = fails_once()
         self.assertEqual(r, 'success')
         self.assertEqual(self.counter, 2)
+    def test_retries_once_type(self):
+        self._retries_once(RetryableError)
+    def test_retries_once_instance(self):
+        self._retries_once(RetryableError('failed'))
 
-    def test_limit_is_reached(self):
+    def _limit_is_reached(self, exception):
         self.counter = 0
 
-        @retry(RetryableError, tries=4, delay=0.1)
+        @retry(exception, tries=4, delay=0.1)
         def always_fails():
             self.counter += 1
             raise RetryableError('failed')
@@ -57,11 +66,15 @@ class RetryTestCase(unittest.TestCase):
         with self.assertRaises(RetryableError):
             always_fails()
         self.assertEqual(self.counter, 4)
+    def test_limit_is_reached_type(self):
+        self._limit_is_reached(RetryableError)
+    def test_limit_is_reached_instance(self):
+        self._limit_is_reached(RetryableError('failed'))
 
-    def test_multiple_exception_types(self):
+    def _multiple_exception_types(self, exceptions):
         self.counter = 0
 
-        @retry((RetryableError, AnotherRetryableError), tries=4, delay=0.1)
+        @retry(exceptions, tries=4, delay=0.1)
         def raise_multiple_exceptions():
             self.counter += 1
             if self.counter == 1:
@@ -74,15 +87,74 @@ class RetryTestCase(unittest.TestCase):
         r = raise_multiple_exceptions()
         self.assertEqual(r, 'success')
         self.assertEqual(self.counter, 3)
+    def test_multiple_exception_types_type(self):
+        self._multiple_exception_types((RetryableError, AnotherRetryableError))
+    def test_multiple_exception_types_instance(self):
+        self._multiple_exception_types((RetryableError('a retryable error'), AnotherRetryableError('another retryable error')))
+    def test_multiple_exception_types_mixed1(self):
+        self._multiple_exception_types((RetryableError, AnotherRetryableError('another retryable error')))
+    def test_multiple_exception_types_mixed2(self):
+        self._multiple_exception_types((RetryableError('a retryable error'), AnotherRetryableError))
 
-    def test_unexpected_exception_does_not_retry(self):
+    def _unexpected_exception_does_not_retry(self, exception):
 
-        @retry(RetryableError, tries=4, delay=0.1)
+        @retry(exception, tries=4, delay=0.1)
         def raise_unexpected_error():
             raise UnexpectedError('unexpected error')
 
         with self.assertRaises(UnexpectedError):
             raise_unexpected_error()
+    def test_unexpected_exception_does_not_retry_type(self):
+        self._unexpected_exception_does_not_retry(RetryableError)
+    def test_unexpected_exception_does_not_retry_instance(self):
+        self._unexpected_exception_does_not_retry(RetryableError())
+
+    def _specific_exception(self, exception, expect_success):
+        self.counter = 0
+
+        @retry((AnotherRetryableError, RetryableError(errno.ECOMM), UnexpectedError), tries=4, delay=0.1)
+        def fails_once():
+            self.counter += 1
+            if self.counter < 2:
+                # The passed exception is an instance, not a type - needed so we can
+                # test that we only catch the instances specified, not all instances of the same type
+                raise exception
+            else:
+                return 'success'
+
+        if expect_success:
+            # should retry once, with exception swallowed, and then succeed
+            r = fails_once()
+            self.assertEqual(r, 'success')
+            self.assertEqual(self.counter, 2)
+        else:
+            # the exception shouldn't be swallowed, will fail first time
+            # assertRaises needs an exception type, not an instance
+            with self.assertRaises(type(exception)):
+                fails_once()
+            self.assertEqual(self.counter, 1)
+
+    def test_specific_exception_type_uncaught(self):
+        # an exception type we don't catch, without args
+        self._specific_exception(ValueError(), False)
+    def test_specific_exception_type_caught1(self):
+        # an exception type we do catch, without args
+        self._specific_exception(AnotherRetryableError(), True)
+    def test_specific_exception_type_caught2(self):
+        # the other exception type we do catch, without args
+        self._specific_exception(UnexpectedError(), True)
+    def test_specific_exception_instance_caught1(self):
+        # an exception type we do catch, with args we should catch
+        self._specific_exception(RetryableError(errno.ECOMM), True)
+    def test_specific_exception_instance_caught2(self):
+        # an exception type we do catch, but with args specified
+        self._specific_exception(AnotherRetryableError(errno.ECOMM), True)
+    def test_specific_exception_instance_uncaught1(self):
+        # an exception type we don't catch, but with args matching those we do catch for another exception
+        self._specific_exception(ValueError(errno.ECOMM), False)
+    def test_specific_exception_instance_uncaught2(self):
+        # an exception type we do catch, but with args we don't catch
+        self._specific_exception(RetryableError(errno.EINVAL), False)
 
     def test_using_a_logger(self):
         self.counter = 0


### PR DESCRIPTION
Enhance retry decorator to allow not just catching of types of exceptions (eg. IOError), but specific instances of those exceptions (eg. catch IOError(errno.ECOMM), but not IOError(errno.EINVAL))

Also add "silent" flag to allow no output from decorators

UT modified to match these changes, details below, also see test output

```
Extended existing tests:
========================
a) pass without my change:
test_no_retry_required_instance - will pass without changes (as it succeeds always)
test_unexpected_exception_does_not_retry_instance - passing exception instance doesn't affect the test, the UnexpectedError is still uncaught

b) fail without my change, pass with it:
test_retries_once_instance - fails to catch specific exception instance, without my change
test_multiple_exception_types_instance - ditto
test_multiple_exception_types_mixed1 - ditto
test_multiple_exception_types_mixed2 - ditto
test_limit_is_reached_instance - again, specific exception instance is uncaught, but test code catches it - yet we can see no retry is done from counter (so hit assertion)

New tests:
==========
Most will pass without my change, as exception instances are never caught
(these are mostly negative tests to check my change doesn't swallow more exceptions than it should -
 eg. RetryableError(errno.EINVAL) when only RetryableError(errno.ECOMM) is specified))

a) pass without my change:
test_specific_exception_type_uncaught - really just a quick sanity test of my new function :)
test_specific_exception_type_caught1 - ditto
test_specific_exception_type_caught2 - ditto
test_specific_exception_instance_caught2
test_specific_exception_instance_uncaught1
test_specific_exception_instance_uncaught2

b) fail without my change, pass with it:
test_specific_exception_instance_caught1 - fails without my change, passes with

Test output
=========
- unchanged code
- patch in test changes, run on unchanged code - some new failures
- patch in real change - all tests pass


pi@RPi-Printer ~/mopi/retry-decorator $ git diff
pi@RPi-Printer ~/mopi/retry-decorator $ python test_decorators.py 
failed, Retrying in 0 seconds...
failed, Retrying in 0 seconds...
failed, Retrying in 0 seconds...
.a retryable error, Retrying in 0 seconds...
another retryable error, Retrying in 0 seconds...
..failed, Retrying in 0 seconds...
..failed, Retrying in 0 seconds...
.
----------------------------------------------------------------------
Ran 6 tests in 1.234s

OK
pi@RPi-Printer ~/mopi/retry-decorator $ 
pi@RPi-Printer ~/mopi/retry-decorator $ patch < ../retry_decorator.ut.final.diff
patching file test_decorators.py
pi@RPi-Printer ~/mopi/retry-decorator $ python test_decorators.py
Ffailed, Retrying in 0 seconds...
failed, Retrying in 0 seconds...
failed, Retrying in 0 seconds...
.Ea retryable error, Retrying in 0 seconds...
EEa retryable error, Retrying in 0 seconds...
another retryable error, Retrying in 0 seconds...
...Efailed, Retrying in 0 seconds...
.E70, Retrying in 0 seconds...
..., Retrying in 0 seconds...
., Retrying in 0 seconds...
....failed, Retrying in 0 seconds...
.
======================================================================
ERROR: test_multiple_exception_types_instance (__main__.RetryTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_decorators.py", line 93, in test_multiple_exception_types_instance
    self._multiple_exception_types((RetryableError('a retryable error'), AnotherRetryableError('another retryable error')))
  File "test_decorators.py", line 87, in _multiple_exception_types
    r = raise_multiple_exceptions()
  File "/home/pi/mopi/retry-decorator/decorators.py", line 31, in f_retry
    return f(*args, **kwargs)
  File "test_decorators.py", line 81, in raise_multiple_exceptions
    raise RetryableError('a retryable error')
RetryableError: a retryable error

======================================================================
ERROR: test_multiple_exception_types_mixed1 (__main__.RetryTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_decorators.py", line 95, in test_multiple_exception_types_mixed1
    self._multiple_exception_types((RetryableError, AnotherRetryableError('another retryable error')))
  File "test_decorators.py", line 87, in _multiple_exception_types
    r = raise_multiple_exceptions()
  File "/home/pi/mopi/retry-decorator/decorators.py", line 31, in f_retry
    return f(*args, **kwargs)
  File "test_decorators.py", line 83, in raise_multiple_exceptions
    raise AnotherRetryableError('another retryable error')
AnotherRetryableError: another retryable error

======================================================================
ERROR: test_multiple_exception_types_mixed2 (__main__.RetryTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_decorators.py", line 97, in test_multiple_exception_types_mixed2
    self._multiple_exception_types((RetryableError('a retryable error'), AnotherRetryableError))
  File "test_decorators.py", line 87, in _multiple_exception_types
    r = raise_multiple_exceptions()
  File "/home/pi/mopi/retry-decorator/decorators.py", line 31, in f_retry
    return f(*args, **kwargs)
  File "test_decorators.py", line 81, in raise_multiple_exceptions
    raise RetryableError('a retryable error')
RetryableError: a retryable error

======================================================================
ERROR: test_retries_once_instance (__main__.RetryTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_decorators.py", line 56, in test_retries_once_instance
    self._retries_once(RetryableError('failed'))
  File "test_decorators.py", line 50, in _retries_once
    r = fails_once()
  File "/home/pi/mopi/retry-decorator/decorators.py", line 31, in f_retry
    return f(*args, **kwargs)
  File "test_decorators.py", line 46, in fails_once
    raise RetryableError('failed')
RetryableError: failed

======================================================================
ERROR: test_specific_exception_instance_caught1 (__main__.RetryTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_decorators.py", line 148, in test_specific_exception_instance_caught1
    self._specific_exception(RetryableError(errno.ECOMM), True)
  File "test_decorators.py", line 127, in _specific_exception
    r = fails_once()
  File "/home/pi/mopi/retry-decorator/decorators.py", line 31, in f_retry
    return f(*args, **kwargs)
  File "test_decorators.py", line 121, in fails_once
    raise exception
RetryableError: 70

======================================================================
FAIL: test_limit_is_reached_instance (__main__.RetryTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_decorators.py", line 72, in test_limit_is_reached_instance
    self._limit_is_reached(RetryableError('failed'))
  File "test_decorators.py", line 68, in _limit_is_reached
    self.assertEqual(self.counter, 4)   
AssertionError: 1 != 4

----------------------------------------------------------------------
Ran 20 tests in 1.685s

FAILED (failures=1, errors=5)
pi@RPi-Printer ~/mopi/retry-decorator $
pi@RPi-Printer ~/mopi/retry-decorator $ patch < ../retry_decorator.final.diff 
patching file decorators.py
pi@RPi-Printer ~/mopi/retry-decorator $ python test_decorators.py 
failed, Retrying in 0 seconds...
failed, Retrying in 0 seconds...
failed, Retrying in 0 seconds...
.failed, Retrying in 0 seconds...
failed, Retrying in 0 seconds...
failed, Retrying in 0 seconds...
.a retryable error, Retrying in 0 seconds...
another retryable error, Retrying in 0 seconds...
.a retryable error, Retrying in 0 seconds...
another retryable error, Retrying in 0 seconds...
.a retryable error, Retrying in 0 seconds...
another retryable error, Retrying in 0 seconds...
.a retryable error, Retrying in 0 seconds...
another retryable error, Retrying in 0 seconds...
...failed, Retrying in 0 seconds...
.failed, Retrying in 0 seconds...
.70, Retrying in 0 seconds...
.70, Retrying in 0 seconds...
...AnotherRetryableError(), Retrying in 0 seconds...
.UnexpectedError(), Retrying in 0 seconds...
....failed, Retrying in 0 seconds...
.
----------------------------------------------------------------------
Ran 20 tests in 3.407s

OK
pi@RPi-Printer ~/mopi/retry-decorator $ 
```
